### PR TITLE
chore: update the proxyconfgen module path

### DIFF
--- a/jylibs/commands.py
+++ b/jylibs/commands.py
@@ -16,7 +16,7 @@ from com.zimbra.cs.account.ldap import LdapProvisioning
 from com.zimbra.common.localconfig import LC
 from com.zimbra.cs.extension import ExtensionDispatcherServlet
 from com.zimbra.cs.httpclient import URLUtil
-from com.zimbra.cs.util import ProxyConfGen
+from com.zimbra.cs.util.proxyconfgen import ProxyConfGen
 
 exe = {
 	"POSTCONF"      : "bin/postconf -e",


### PR DESCRIPTION
update the `proxyconfgen` module path according to the new changes made in https://github.com/Zextras/carbonio-mailbox/pull/45